### PR TITLE
Update github-star count on open-source CMSs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,24 @@ A collection of awesome Jekyll editors
 
 ### Open Source
 
-- **Jekyll Admin** ★565 (github: [jekyll/jekyll-admin](https://github.com/jekyll/jekyll-admin)) by Ben Balter, Mert Kahyaoğlu et al -- a jekyll plugin offering a classic CMS-style "visual" editor in your browser to write posts and manage jekyll sites
+- **Netlify CMS** ★9,246  (github: [netlify/netlify-cms](https://github.com/netlify/netlify-cms)) -- a content management system (CMS) for static site generators
 
-- **Prose** ★3 418 (web: [prose.io](http://prose.io), github: [prose/prose](https://github.com/prose/prose)) -- a content editor for GitHub designed for managing (web)sites
+- **Prose** ★4,225 (web: [prose.io](http://prose.io), github: [prose/prose](https://github.com/prose/prose)) -- a content editor for GitHub designed for managing (web)sites
 
+- **Jekyll Admin** ★2,058  (github: [jekyll/jekyll-admin](https://github.com/jekyll/jekyll-admin)) by Ben Balter, Mert Kahyaoğlu et al -- a jekyll plugin offering a classic CMS-style "visual" editor in your browser to write posts and manage jekyll sites
+
+- **Federalist** ★210 (web: [federalist.18f.gov](https://federalist.18f.gov), github: [18F/federalist](https://github.com/18F/federalist)) by 18F (a US government agency) -- a content management system (CMS) for publishing static government websites; automates common tasks for integrating GitHub, Prose, and Amazon Web Services offering a simple way for developers to launch new websites or more easily manage existing ones
+
+<!--
+discontinued:
 - **Utterson** ★153 (github: [gabriel-john/utterson](https://github.com/gabriel-john/utterson)) -- web backend written in ruby, for a more user friendly management of jekyll sites; (work-in-progess)
+-->
 
-- **Little Jekyll** ★23 (github: [L-A/Little-Jekyll](https://github.com/L-A/Little-Jekyll)) by Louis-André Labadie -- a desktop app to manage Jekyll websites, overview and control your Jekyll processes
+- **MrHyde** ★75 (play store: [org.faudroids.mrhyde](https://play.google.com/store/apps/details?id=org.faudroids.mrhyde), github: [FauDroids/MrHyde](https://github.com/FauDroids/MrHyde)) -- an Android app that can add and edit posts, drafts and files that can be previewed
 
-- **Content Editor** ★25 (github: [mushishi78/content-editor](https://github.com/mushishi78/content-editor)) by Max White -- a web interface for editing documents on GitHub
+- **Little Jekyll** ★40  (github: [L-A/Little-Jekyll](https://github.com/L-A/Little-Jekyll)) by Louis-André Labadie -- a desktop app to manage Jekyll websites, overview and control your Jekyll processes
 
-- **Netlify CMS** ★550 (github: [netlify/netlify-cms](https://github.com/netlify/netlify-cms)) -- a content management system (CMS) for static site generators
-
-- **MrHyde** ★57 (play store: [org.faudroids.mrhyde](https://play.google.com/store/apps/details?id=org.faudroids.mrhyde), github: [FauDroids/MrHyde](https://github.com/FauDroids/MrHyde)) -- an Android app that can add and edit posts, drafts and files that can be previewed
-
-- **Federalist** ★19 (web: [federalist.18f.gov](https://federalist.18f.gov), github: [18F/federalist](https://github.com/18F/federalist)) by 18F (a US government agency) -- a content management system (CMS) for publishing static government websites; automates common tasks for integrating GitHub, Prose, and Amazon Web Services offering a simple way for developers to launch new websites or more easily manage existing ones
-
+- **Content Editor** ★39 (github: [mushishi78/content-editor](https://github.com/mushishi78/content-editor)) by Max White -- a web interface for editing documents on GitHub
 
 ### Commerical / For Pay
 


### PR DESCRIPTION
Pretty sure you hack together a script to update the star count using the github repo api.  This was quicker.